### PR TITLE
Update adb.md

### DIFF
--- a/docs/adb.md
+++ b/docs/adb.md
@@ -85,7 +85,7 @@ kubectl create secret generic <ADMIN-PASSWORD-SECRET-NAME> --from-literal=passwo
 The Autonomous Database can be accessed using the details in the wallet which will be downloaded as part of the provision/bind operation of the CR. OSOK acquires the wallet password from the Kubernetes secret whose name is provided in the `spec`. Also, we can configure the name of the wallet in the `spec`.
 
 ```sh
-kubectl create secret generic <WALLET-PASSWORD-SECRET-NAME> --from-literal=walletpassword=<WALLET-PASSWORD>
+kubectl create secret generic <WALLET-PASSWORD-SECRET-NAME> --from-literal=walletPassword=<WALLET-PASSWORD>
 ```
 
 The OSOK AutonomousDatabases controller automatically provisions an Autonomous Database when you provides mandatory fields to the `spec`. the following is a sample YAML for Autonomous Database.


### PR DESCRIPTION
To prevent this error: 'Warning  Failed   2m15s (x2 over 2m16s)  AutonomousDatabases  Failed to create or update resource: password key 'walletPassword' in wallet password secret is not found', it is required to change from p to P.