### PR TITLE
Release v1.1.3 for OCI Service Operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,9 +186,9 @@ bundle-push: ## Push the bundle image.
 
 .PHONY: update-bundle-image-version
 update-bundle-image-version: ## Updates versioning info in bundle/manifests/oci-service-operator.clusterserviceversion.yaml.
-	sed -i "s/name: oci-service-operator.v0.0.1/name: oci-service-operator.v${VERSION}/g" bundle/manifests/oci-service-operator.clusterserviceversion.yaml
-	sed -i "s/oci-service-operator:v0.0.2/oci-service-operator:${VERSION}/g" bundle/manifests/oci-service-operator.clusterserviceversion.yaml
-	sed -i "s/version: 0.0.1/version: ${VERSION}/g" bundle/manifests/oci-service-operator.clusterserviceversion.yaml
+	sed -i "s/name: oci-service-operator.v1.0.0/name: oci-service-operator.v${VERSION}/g" bundle/manifests/oci-service-operator.clusterserviceversion.yaml
+	sed -i "s#iad.ocir.io/oracle/oci-service-operator:1.0.0#${IMAGE_TAG_BASE}:${VERSION}#g" bundle/manifests/oci-service-operator.clusterserviceversion.yaml
+	sed -i "s/version: 1.0.0/version: ${VERSION}/g" bundle/manifests/oci-service-operator.clusterserviceversion.yaml
 
 .PHONY: opm
 OPM = ./bin/opm

--- a/apis/servicemesh.oci/v1beta1/ingressgatewaydeployment_types.go
+++ b/apis/servicemesh.oci/v1beta1/ingressgatewaydeployment_types.go
@@ -79,6 +79,10 @@ type IngressDeployment struct {
 
 	// +optional
 	Labels map[string]string `json:"labels,omitempty" protobuf:"bytes,11,rep,name=labels"`
+
+	// indicates whether to mount `/etc/pki` host path to the container.
+	// +optional
+	MountCertificateChainFromHost *bool `json:"mountCertificateChainFromHost,omitempty"`
 }
 
 // Reference to kubernetes secret containing tls certificates/trust-chains for ingress gateway

--- a/apis/servicemesh.oci/v1beta1/virtualdeploymentbinding_types.go
+++ b/apis/servicemesh.oci/v1beta1/virtualdeploymentbinding_types.go
@@ -21,6 +21,10 @@ type VirtualDeploymentBindingSpec struct {
 
 	// +optional
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// indicates whether to mount `/etc/pki` host path to the container.
+	// +optional
+	MountCertificateChainFromHost *bool `json:"mountCertificateChainFromHost,omitempty"`
 }
 
 // Target identifies the Virtual Deployment for a Virtual Deployment Binding

--- a/config/crd/bases/servicemesh.oci.oracle.com_ingressgatewaydeployments.yaml
+++ b/config/crd/bases/servicemesh.oci.oracle.com_ingressgatewaydeployments.yaml
@@ -115,6 +115,10 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  mountCertificateChainFromHost:
+                    description: indicates whether to mount `/etc/pki` host path to
+                      the container.
+                    type: boolean
                 required:
                 - autoscaling
                 type: object

--- a/config/crd/bases/servicemesh.oci.oracle.com_virtualdeploymentbindings.yaml
+++ b/config/crd/bases/servicemesh.oci.oracle.com_virtualdeploymentbindings.yaml
@@ -61,6 +61,10 @@ spec:
             description: VirtualDeploymentBindingSpec defines the desired state of
               VirtualDeploymentBinding
             properties:
+              mountCertificateChainFromHost:
+                description: indicates whether to mount `/etc/pki` host path to the
+                  container.
+                type: boolean
               resources:
                 description: ResourceRequirements describes the compute resource requirements.
                 properties:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -118,4 +118,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        volumeMounts:
+          - name: pki
+            mountPath: /etc/pki
+            readOnly: true
+      volumes:
+        - name: pki
+          hostPath:
+            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/samples/servicemesh.oci_v1beta1_ingressgatewaydeployment.yaml
+++ b/config/samples/servicemesh.oci_v1beta1_ingressgatewaydeployment.yaml
@@ -18,6 +18,7 @@ spec:
     autoscaling:
       minPods: 1
       maxPods: 1
+    mountCertificateChainFromHost: true
   ports:
     - protocol: TCP
       port: 8080

--- a/config/samples/servicemesh.oci_v1beta1_virtualdeploymentbinding.yaml
+++ b/config/samples/servicemesh.oci_v1beta1_virtualdeploymentbinding.yaml
@@ -17,3 +17,4 @@ spec:
       ref:
         name: productpage
         namespace: bookinfo
+  mountCertificateChainFromHost: true

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -200,3 +200,10 @@ The OCI Service Operator for Kubernetes can be undeployed easily using the OLM
 ```bash
 $ operator-sdk cleanup oci-service-operator
 ```
+
+### Customize CA trust bundle
+
+The OCI Service Operator for Kubernetes by default mounts the `/etc/pki` host path so that the host
+certificate chains can be used for TLS verification. The default container image is built on top of
+Oracle Linux 7 which has the default CA trust bundle under `/etc/pki`. A new container image can be
+created with a custom CA trust bundle.

--- a/docs/service-mesh/ingress-gateway-deployment.md
+++ b/docs/service-mesh/ingress-gateway-deployment.md
@@ -46,10 +46,11 @@ The Complete Specification of the `IngressGatewayDeployment` Custom Resource (CR
 | `name` | The name of the resource. | string | yes       |
 
 ### Deployment
-| Parameter                          | Description                                                         | Type   | Mandatory |
-| ---------------------------------- | ------------------------------------------------------------------- | ------ | --------- |
-| `autoscaling` | Contains information about min and max replicas for Ingress Gateway Deployment Resource | [Autoscaling](#autoscaling) | yes       |
-| `labels` | Additional label information for Ingress Gateway Deployment | string | no        |
+| Parameter                       | Description                                                                             | Type                        | Mandatory |
+|---------------------------------|-----------------------------------------------------------------------------------------|-----------------------------|-----------|
+| `autoscaling`                   | Contains information about min and max replicas for Ingress Gateway Deployment Resource | [Autoscaling](#autoscaling) | yes       |
+| `labels`                        | Additional label information for Ingress Gateway Deployment                             | string                      | no        |
+| `mountCertificateChainFromHost` | Indicates whether to mount `/etc/pki` host path to the container                        | bool                        | no        |
 
 ### Autoscaling
 | Parameter                          | Description                                                         | Type   | Mandatory |
@@ -123,6 +124,7 @@ spec:
     autoscaling:
       minPods: 1
       maxPods: 1
+    mountCertificateChainFromHost: true
   ports:
     - protocol: TCP
       port: 8080
@@ -148,6 +150,7 @@ spec:
     autoscaling:
       minPods: 1
       maxPods: 1
+    mountCertificateChainFromHost: true
   ports:
     - protocol: TCP
       port: 8080
@@ -204,6 +207,7 @@ spec:
     autoscaling:
       minPods: <updated-min-pod-count>
       maxPods: <updated-min-pod-count>
+    mountCertificateChainFromHost: false
   ports:
     - protocol: <updated-protocol>
       port: <updated-port>

--- a/docs/service-mesh/virtual-deployment-binding.md
+++ b/docs/service-mesh/virtual-deployment-binding.md
@@ -23,11 +23,12 @@ This binding resource allows enabling automatic sidecar injection, discover pods
 ## Virtual Deployment Binding Specification Parameters
 The Complete Specification of the `VirtualDeploymentBinding` Custom Resource (CR) is as detailed below:
 
-| Parameter                | Description                                                                                                                             | Type                                          | Mandatory |
-|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|-----------|
-| `spec.virtualDeployment` | The virtual deployment to bind the resource with. Either `spec.virtualDeployment.id` or `spec.virtualDeployment.ref` should be provided | [RefOrId](#reforid)                           | yes       |
-| `spec.target`            | A target kubernetes service to bind the resource with                                                                                   | string                                        | yes       |
-| `spec.resources`         | minimum and maximum compute resource requirements for the sidecar container                                                             | [ResourceRequirements](#resourcerequirements) | no        |
+| Parameter                            | Description                                                                                                                             | Type                                          | Mandatory |
+|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|-----------|
+| `spec.virtualDeployment`             | The virtual deployment to bind the resource with. Either `spec.virtualDeployment.id` or `spec.virtualDeployment.ref` should be provided | [RefOrId](#reforid)                           | yes       |
+| `spec.target`                        | A target kubernetes service to bind the resource with                                                                                   | string                                        | yes       |
+| `spec.resources`                     | minimum and maximum compute resource requirements for the sidecar container                                                             | [ResourceRequirements](#resourcerequirements) | no        |
+| `spec.mountCertificateChainFromHost` | Indicates whether to mount `/etc/pki` host path to the sidecar container                                                                | bool                                          | no        |
 
 ### RefOrId
 | Parameter | Description                                                                                        | Type                        | Mandatory |
@@ -102,6 +103,7 @@ spec:
     limits:
       memory: "128Mi"
       cpu: "500m"
+  mountCertificateChainFromHost: true
 ```
 
 - Create your virtual deployment binding using the virtual deployment OCID.
@@ -128,6 +130,7 @@ spec:
     limits:
       memory: "128Mi"
       cpu: "500m"
+  mountCertificateChainFromHost: true
 ```
 
 Run the following command to create a CR in the cluster:
@@ -179,6 +182,7 @@ spec:
       ref:
         name: <kubernetes-service-name> # Name of Kubernetes Service
         namespace: <kubernetes-service-namespace> # Name of Kubernetes Service namespace
+  mountCertificateChainFromHost: false
 ```
 
 ```sh

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/oracle/oci-go-sdk/v65/common"
+
 	servicemeshcontrollers "github.com/oracle/oci-service-operator/controllers/servicemesh.oci"
 	"github.com/oracle/oci-service-operator/pkg/servicemanager/servicemesh/injectproxy"
 	"github.com/oracle/oci-service-operator/pkg/servicemanager/servicemesh/serviceupdate"
@@ -86,6 +88,9 @@ func init() {
 }
 
 func main() {
+	// Allow OCI go sdk to use instance metadata service for region lookup
+	common.EnableInstanceMetadataServiceLookup()
+
 	var configFile string
 	flag.StringVar(&configFile, "config", "",
 		"The controller will load its initial configuration from this file. "+

--- a/pkg/servicemanager/servicemesh/ingressgatewaydeployment/ingressgatewaydeployment_servicemanager.go
+++ b/pkg/servicemanager/servicemesh/ingressgatewaydeployment/ingressgatewaydeployment_servicemanager.go
@@ -352,6 +352,13 @@ func (h *IngressGatewayDeploymentServiceManager) createDeploymentSpec(ingressGat
 		})
 	}
 
+	volumes := secretVolumes
+	if ingressGatewayDeployment.Spec.Deployment.MountCertificateChainFromHost != nil &&
+		*ingressGatewayDeployment.Spec.Deployment.MountCertificateChainFromHost {
+		volumes = append(secretVolumes, meshCommons.PkiVolume)
+		volumeMounts = append(volumeMounts, meshCommons.PkiVolumeMount)
+	}
+
 	resourceRequests := corev1.ResourceRequirements{
 		Requests: map[corev1.ResourceName]resource.Quantity{
 			corev1.ResourceCPU:    resource.MustParse(string(meshCommons.IngressCPURequestSize)),
@@ -458,7 +465,7 @@ func (h *IngressGatewayDeploymentServiceManager) createDeploymentSpec(ingressGat
 				Containers: []corev1.Container{
 					proxyContainer,
 				},
-				Volumes: secretVolumes,
+				Volumes: volumes,
 			},
 		},
 	}

--- a/pkg/servicemanager/servicemesh/k8s/inject/proxy_container_mutator.go
+++ b/pkg/servicemanager/servicemesh/k8s/inject/proxy_container_mutator.go
@@ -147,6 +147,12 @@ func (mctx *proxyMutator) mutate(pod *corev1.Pod) error {
 		envoy.Env = append(envoy.Env, corev1.EnvVar{Name: commons.MdsEndpointInMeshConfigMap, Value: mctx.mdsEndpoint})
 	}
 
+	if mctx.vdb.Spec.MountCertificateChainFromHost != nil &&
+		*mctx.vdb.Spec.MountCertificateChainFromHost {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, commons.PkiVolume)
+		envoy.VolumeMounts = []corev1.VolumeMount{commons.PkiVolumeMount}
+	}
+
 	pod.Spec.Containers = append(pod.Spec.Containers, envoy)
 	return nil
 }

--- a/pkg/servicemanager/servicemesh/services/servicemesh_client.go
+++ b/pkg/servicemanager/servicemesh/services/servicemesh_client.go
@@ -426,7 +426,7 @@ func (c *defaultServiceMeshClient) CreateAccessPolicy(ctx context.Context, acces
 
 func (c *defaultServiceMeshClient) UpdateAccessPolicy(ctx context.Context, accessPolicy *sdk.AccessPolicy) error {
 	if accessPolicy.Rules == nil {
-		accessPolicy.Rules = [] sdk.AccessPolicyRule{}
+		accessPolicy.Rules = []sdk.AccessPolicyRule{}
 	}
 	_, err := c.client.UpdateAccessPolicy(ctx, sdk.UpdateAccessPolicyRequest{
 		AccessPolicyId: accessPolicy.Id,

--- a/pkg/servicemanager/servicemesh/utils/commons/constants.go
+++ b/pkg/servicemanager/servicemesh/utils/commons/constants.go
@@ -6,6 +6,8 @@
 package commons
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	servicemeshapi "github.com/oracle/oci-service-operator/apis/servicemesh.oci/v1beta1"
 )
 
@@ -268,3 +270,18 @@ const (
 	IngressGatewayDeployment MeshResources = "IngressGatewayDeployment"
 	VirtualDeploymentBinding MeshResources = "VirtualDeploymentBinding"
 )
+
+var PkiVolume = corev1.Volume{
+	Name: "pki",
+	VolumeSource: corev1.VolumeSource{
+		HostPath: &corev1.HostPathVolumeSource{
+			Path: "/etc/pki",
+		},
+	},
+}
+
+var PkiVolumeMount = corev1.VolumeMount{
+	Name:      "pki",
+	ReadOnly:  true,
+	MountPath: "/etc/pki",
+}


### PR DESCRIPTION
New Release v1.1.3 for OCI Service Operator

- Allow custom trust store on operator and custom volumes on Service Mesh proxy
- Allow publishing custom operator image

Co-authored-by: @abhinamm
Co-authored-by: @vivekgg

