### PR TITLE
fix(psql): isolate controller RBAC

### DIFF
--- a/config/manager/psql/manager.yaml
+++ b/config/manager/psql/manager.yaml
@@ -17,6 +17,39 @@ metadata:
 data:
   useinstanceprincipal: dHJ1ZQ==
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,6 +67,7 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      serviceAccountName: controller-manager
       securityContext:
         runAsUser: 65532
       containers:

--- a/controllers/psql/dbsystem_controller.go
+++ b/controllers/psql/dbsystem_controller.go
@@ -24,7 +24,7 @@ type DbSystemReconciler struct {
 // +kubebuilder:rbac:groups=psql.oracle.com,resources=dbsystems/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=psql.oracle.com,resources=dbsystems/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get
 
 // Reconcile is part of the main Kubernetes reconciliation loop.
 func (r *DbSystemReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/docs/api-generator-contract.md
+++ b/docs/api-generator-contract.md
@@ -22,6 +22,7 @@ Each service record defines:
 | `sampleOrder` | Optional deterministic ordering hint for generated sample entries. |
 | `packageProfile` | Install posture for the group: `controller-backed` or `crd-only`. |
 | `package.extraResources` | Optional extra package overlay resources to include in the generated install kustomization. |
+| `package.dedicatedServiceAccount` | When true, generate a package-specific manager ServiceAccount and its manager and leader-election bindings instead of binding those roles to the shared default ServiceAccount. |
 | `selection.enabled` | Whether the service participates in the default active generator surface. |
 | `selection.mode` | Default selection contract for the service: `all` or `explicit`. |
 | `selection.includeKinds` | Optional non-empty kind list used only when `selection.mode=explicit`. |

--- a/internal/generator/checked_in_rbac_test.go
+++ b/internal/generator/checked_in_rbac_test.go
@@ -39,7 +39,7 @@ func TestCheckedInDatabaseAutonomousDatabasePackageRBACMatchesReadOnlySecretSema
 func TestCheckedInPSQLDbSystemPackageRBACMatchesSecretAndEventRecorderSemantics(t *testing.T) {
 	controllerPath := filepath.Join(repoRoot(t), "controllers", "psql", "dbsystem_controller.go")
 	assertFileContains(t, controllerPath, []string{
-		`// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch`,
+		`// +kubebuilder:rbac:groups="",resources=secrets,verbs=get`,
 		`// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch`,
 	})
 	assertFileDoesNotContain(t, controllerPath, []string{
@@ -52,9 +52,22 @@ func TestCheckedInPSQLDbSystemPackageRBACMatchesSecretAndEventRecorderSemantics(
 		filepath.Join(repoRoot(t), "packages", "psql", "install", "generated", "rbac", "role.yaml"),
 		map[string][]string{
 			"events":  {"create", "patch"},
-			"secrets": {"get", "list", "watch"},
+			"secrets": {"get"},
 		},
 	)
+
+	managerPath := filepath.Join(repoRoot(t), "config", "manager", "psql", "manager.yaml")
+	assertFileContains(t, managerPath, []string{
+		"kind: ServiceAccount",
+		"name: controller-manager",
+		"kind: ClusterRoleBinding",
+		"kind: RoleBinding",
+		"serviceAccountName: controller-manager",
+	})
+	assertFileDoesNotContain(t, filepath.Join(repoRoot(t), "packages", "psql", "install", "kustomization.yaml"), []string{
+		"../../../config/rbac/role_binding.yaml",
+		"../../../config/rbac/leader_election_role_binding.yaml",
+	})
 }
 
 func TestCheckedInRedisClusterPackageRBACMatchesEventRecorderSemantics(t *testing.T) {

--- a/internal/generator/config.go
+++ b/internal/generator/config.go
@@ -64,6 +64,9 @@ type PackageProfile struct {
 // PackageConfig describes service-scoped package overlay details.
 type PackageConfig struct {
 	ExtraResources []string `yaml:"extraResources,omitempty"`
+	// DedicatedServiceAccount isolates a package manager from the shared default
+	// service account and its role bindings.
+	DedicatedServiceAccount bool `yaml:"dedicatedServiceAccount,omitempty"`
 }
 
 // SelectionConfig declares whether a service participates in the default active surface.

--- a/internal/generator/config/services.yaml
+++ b/internal/generator/config/services.yaml
@@ -6734,6 +6734,8 @@ services:
       mode: explicit
       includeKinds:
         - DbSystem
+    package:
+      dedicatedServiceAccount: true
     generation:
       controller:
         strategy: generated
@@ -6752,7 +6754,7 @@ services:
             formalClassification: lifecycle
           controller:
             extraRBACMarkers:
-              - groups="",resources=secrets,verbs=get;list;watch
+              - groups="",resources=secrets,verbs=get
           specFields:
             - name: AdminUsername
               type: shared.UsernameSource

--- a/internal/generator/config_test.go
+++ b/internal/generator/config_test.go
@@ -2951,10 +2951,13 @@ func assertPSQLRuntimeRolloutMetadata(t *testing.T, service *ServiceConfig) {
 	if override.Kind != "DbSystem" {
 		t.Fatalf("psql override kind = %q, want %q", override.Kind, "DbSystem")
 	}
+	if !service.Package.DedicatedServiceAccount {
+		t.Fatal("psql dedicatedServiceAccount = false, want true")
+	}
 	if !slices.Equal(
 		override.Controller.ExtraRBACMarkers,
 		[]string{
-			`groups="",resources=secrets,verbs=get;list;watch`,
+			`groups="",resources=secrets,verbs=get`,
 		},
 	) {
 		t.Fatalf("psql extra RBAC markers = %v, want secret read markers only", override.Controller.ExtraRBACMarkers)

--- a/internal/generator/package_model.go
+++ b/internal/generator/package_model.go
@@ -146,13 +146,15 @@ func buildPackageOutputModelFor(service ServiceConfig, outputName string, defaul
 			"generated/crd",
 			"generated/rbac",
 			managerOverlay,
-			"../../../config/rbac/leader_election_role.yaml",
 		)
 		if !service.Package.DedicatedServiceAccount {
 			output.Install.Resources = append(output.Install.Resources,
 				"../../../config/rbac/role_binding.yaml",
-				"../../../config/rbac/leader_election_role_binding.yaml",
 			)
+		}
+		output.Install.Resources = append(output.Install.Resources, "../../../config/rbac/leader_election_role.yaml")
+		if !service.Package.DedicatedServiceAccount {
+			output.Install.Resources = append(output.Install.Resources, "../../../config/rbac/leader_election_role_binding.yaml")
 		}
 		output.Install.Resources = appendUniqueStrings(output.Install.Resources, service.Package.ExtraResources...)
 		if service.WebhookGenerationStrategy() == GenerationStrategyManual {

--- a/internal/generator/package_model.go
+++ b/internal/generator/package_model.go
@@ -146,10 +146,14 @@ func buildPackageOutputModelFor(service ServiceConfig, outputName string, defaul
 			"generated/crd",
 			"generated/rbac",
 			managerOverlay,
-			"../../../config/rbac/role_binding.yaml",
 			"../../../config/rbac/leader_election_role.yaml",
-			"../../../config/rbac/leader_election_role_binding.yaml",
 		)
+		if !service.Package.DedicatedServiceAccount {
+			output.Install.Resources = append(output.Install.Resources,
+				"../../../config/rbac/role_binding.yaml",
+				"../../../config/rbac/leader_election_role_binding.yaml",
+			)
+		}
 		output.Install.Resources = appendUniqueStrings(output.Install.Resources, service.Package.ExtraResources...)
 		if service.WebhookGenerationStrategy() == GenerationStrategyManual {
 			output.Install.Resources = appendUniqueStrings(output.Install.Resources,

--- a/internal/generator/render.go
+++ b/internal/generator/render.go
@@ -214,7 +214,7 @@ func (r *Renderer) RenderManagerOutputs(root string, pkg *PackageModel, overwrit
 		return err
 	}
 
-	managerDeploymentContent, err := renderManagerDeploymentFile()
+	managerDeploymentContent, err := renderManagerDeploymentFile(pkg.Service.Package.DedicatedServiceAccount)
 	if err != nil {
 		return fmt.Errorf("render manager deployment for %s: %w", pkg.Service.Service, err)
 	}
@@ -470,8 +470,12 @@ func renderManagerKustomizationFile() (string, error) {
 	return executeTemplate(managerKustomizationTemplate, struct{}{})
 }
 
-func renderManagerDeploymentFile() (string, error) {
-	return executeTemplate(managerDeploymentTemplate, struct{}{})
+func renderManagerDeploymentFile(dedicatedServiceAccount bool) (string, error) {
+	return executeTemplate(managerDeploymentTemplate, struct {
+		DedicatedServiceAccount bool
+	}{
+		DedicatedServiceAccount: dedicatedServiceAccount,
+	})
 }
 
 func renderControllerManagerConfigFile(group string) (string, error) {
@@ -1689,6 +1693,41 @@ metadata:
   name: osokconfig
 data:
   useinstanceprincipal: dHJ1ZQ==
+{{- if .DedicatedServiceAccount}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system
+{{- end}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1707,6 +1746,9 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+{{- if .DedicatedServiceAccount}}
+      serviceAccountName: controller-manager
+{{- end}}
       securityContext:
         runAsUser: 65532
       containers:

--- a/packages/psql/install/generated/rbac/role.yaml
+++ b/packages/psql/install/generated/rbac/role.yaml
@@ -17,8 +17,6 @@ rules:
   - secrets
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - psql.oracle.com
   resources:

--- a/packages/psql/install/kustomization.yaml
+++ b/packages/psql/install/kustomization.yaml
@@ -8,9 +8,7 @@ resources:
 - generated/crd
 - generated/rbac
 - ../../../config/manager/psql
-- ../../../config/rbac/role_binding.yaml
 - ../../../config/rbac/leader_election_role.yaml
-- ../../../config/rbac/leader_election_role_binding.yaml
 
 patches:
 - path: ../../../config/default/manager_config_patch.yaml

--- a/pkg/manager/run.go
+++ b/pkg/manager/run.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -195,11 +196,7 @@ func Run(opts Options, registrars ...RegisterFunc) error {
 
 	metricsClient := metrics.Init(opts.MetricsServiceName, loggerutil.OSOKLogger{Logger: ctrl.Log.WithName("metrics")})
 
-	credClient := &kubesecret.KubeSecretClient{
-		Client:  mgr.GetClient(),
-		Log:     loggerutil.OSOKLogger{Logger: ctrl.Log.WithName("credential-helper").WithName("KubeSecretClient")},
-		Metrics: metricsClient,
-	}
+	credClient := newCredentialClient(mgr, metricsClient)
 
 	deps := &Dependencies{
 		Provider:   provider,
@@ -233,6 +230,20 @@ func Run(opts Options, registrars ...RegisterFunc) error {
 		return err
 	}
 	return nil
+}
+
+type credentialClientManager interface {
+	GetClient() ctrlclient.Client
+	GetAPIReader() ctrlclient.Reader
+}
+
+func newCredentialClient(mgr credentialClientManager, metricsClient *metrics.Metrics) *kubesecret.KubeSecretClient {
+	return kubesecret.NewWithReader(
+		mgr.GetClient(),
+		mgr.GetAPIReader(),
+		loggerutil.OSOKLogger{Logger: ctrl.Log.WithName("credential-helper").WithName("KubeSecretClient")},
+		metricsClient,
+	)
 }
 
 func loadManagerOptionsFromFile(path string, options ctrl.Options) (ctrl.Options, error) {

--- a/pkg/manager/run_test.go
+++ b/pkg/manager/run_test.go
@@ -1,0 +1,69 @@
+package manager
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNewCredentialClientUsesAPIReaderForSecretReads(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "credential", Namespace: "default"},
+		Data:       map[string][]byte{"key": []byte("value")},
+	}
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret.DeepCopy()).Build()
+	cachedClient := &staleSecretGetClient{
+		Client: apiReader,
+		getErr: apierrors.NewNotFound(corev1.Resource("secrets"), secret.Name),
+	}
+
+	credClient := newCredentialClient(&fakeCredentialClientManager{
+		client:    cachedClient,
+		apiReader: apiReader,
+	}, nil)
+
+	data, err := credClient.GetSecret(context.Background(), secret.Name, secret.Namespace)
+	if err != nil {
+		t.Fatalf("GetSecret() error = %v", err)
+	}
+	if !reflect.DeepEqual(data, secret.Data) {
+		t.Fatalf("GetSecret() data = %v, want %v", data, secret.Data)
+	}
+	if cachedClient.getCalls != 0 {
+		t.Fatalf("cached client Get calls = %d, want 0", cachedClient.getCalls)
+	}
+}
+
+type staleSecretGetClient struct {
+	ctrlclient.Client
+	getCalls int
+	getErr   error
+}
+
+func (c *staleSecretGetClient) Get(ctx context.Context, key ctrlclient.ObjectKey, obj ctrlclient.Object, opts ...ctrlclient.GetOption) error {
+	c.getCalls++
+	return c.getErr
+}
+
+type fakeCredentialClientManager struct {
+	client    ctrlclient.Client
+	apiReader ctrlclient.Reader
+}
+
+func (m *fakeCredentialClientManager) GetClient() ctrlclient.Client { return m.client }
+
+func (m *fakeCredentialClientManager) GetAPIReader() ctrlclient.Reader { return m.apiReader }


### PR DESCRIPTION
  solve: https://jira.oci.oraclecorp.com/browse/OKE-44458
  
  ## Summary

  Moves the PostgreSQL controller off the shared `default` ServiceAccount and reduces its Secret access to least privilege.

  ## Changes

  - Generate a dedicated PSQL manager ServiceAccount.
  - Bind the PSQL manager and leader-election roles to that account.
  - Remove the PSQL package’s shared/default-ServiceAccount bindings.
  - Reduce PSQL Secret RBAC from `get,list,watch` to `get`.
  - Read credential Secrets through `mgr.GetAPIReader()` rather than the controller-runtime cache, avoiding the Secret informer
  requirement for `list` and `watch`.
  - Preserve existing resource ordering for non-dedicated generated packages.
  - Add regression coverage proving credential reads bypass the cached client.

  ## Validation

  - `go test ./pkg/manager ./internal/generator/...`
  - `go build ./...`
  - `go vet ./...`
  - Rendered PSQL package verification:
    - dedicated ServiceAccount is used
    - no binding to `default`
    - Secrets permission is `get` only
  - Live OKE test using the pushed PSQL image:
    - image ran with the dedicated ServiceAccount
    - instance-principal authentication succeeded
    - `get secrets` allowed; `list/watch secrets` denied
    - Secret-backed `DbSystem` reconciliation performed a named Secret GET and returned expected `NotFound`, not RBAC `Forbidden`