### PR TITLE
fix(manager): support Restricted Pod Security without host CA mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" CGO_ENABLED="${CGO_ENABLED}" GOEXP
 FROM oraclelinux:9-slim
 WORKDIR /
 
+RUN rpm -q ca-certificates && test -s /etc/pki/tls/certs/ca-bundle.crt
+
 COPY --from=builder /workspace/manager .
 
 USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,6 @@ RUN GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" CGO_ENABLED="${CGO_ENABLED}" GOEXP
 FROM oraclelinux:9-slim
 WORKDIR /
 
-RUN rpm -q ca-certificates && test -s /etc/pki/tls/certs/ca-bundle.crt
-
 COPY --from=builder /workspace/manager .
 
 USER 65532:65532

--- a/config/manager/accessgovernancecp/manager.yaml
+++ b/config/manager/accessgovernancecp/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/adm/manager.yaml
+++ b/config/manager/adm/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/aidataplatform/manager.yaml
+++ b/config/manager/aidataplatform/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/aidocument/manager.yaml
+++ b/config/manager/aidocument/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/ailanguage/manager.yaml
+++ b/config/manager/ailanguage/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/aispeech/manager.yaml
+++ b/config/manager/aispeech/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/aivision/manager.yaml
+++ b/config/manager/aivision/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/analytics/manager.yaml
+++ b/config/manager/analytics/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/announcementsservice/manager.yaml
+++ b/config/manager/announcementsservice/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/apiaccesscontrol/manager.yaml
+++ b/config/manager/apiaccesscontrol/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/apigateway/manager.yaml
+++ b/config/manager/apigateway/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/apiplatform/manager.yaml
+++ b/config/manager/apiplatform/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/apmconfig/manager.yaml
+++ b/config/manager/apmconfig/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/apmcontrolplane/manager.yaml
+++ b/config/manager/apmcontrolplane/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/apmsynthetics/manager.yaml
+++ b/config/manager/apmsynthetics/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/apmtraces/manager.yaml
+++ b/config/manager/apmtraces/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/appmgmtcontrol/manager.yaml
+++ b/config/manager/appmgmtcontrol/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/artifacts/manager.yaml
+++ b/config/manager/artifacts/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/autoscaling/manager.yaml
+++ b/config/manager/autoscaling/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/bastion/manager.yaml
+++ b/config/manager/bastion/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/batch/manager.yaml
+++ b/config/manager/batch/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/bds/manager.yaml
+++ b/config/manager/bds/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/blockchain/manager.yaml
+++ b/config/manager/blockchain/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/budget/manager.yaml
+++ b/config/manager/budget/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/capacitymanagement/manager.yaml
+++ b/config/manager/capacitymanagement/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/certificatesmanagement/manager.yaml
+++ b/config/manager/certificatesmanagement/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/cloudbridge/manager.yaml
+++ b/config/manager/cloudbridge/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/cloudguard/manager.yaml
+++ b/config/manager/cloudguard/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/cloudmigrations/manager.yaml
+++ b/config/manager/cloudmigrations/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/clusterplacementgroups/manager.yaml
+++ b/config/manager/clusterplacementgroups/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/computecloudatcustomer/manager.yaml
+++ b/config/manager/computecloudatcustomer/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/computeinstanceagent/manager.yaml
+++ b/config/manager/computeinstanceagent/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/containerengine/manager.yaml
+++ b/config/manager/containerengine/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/containerinstances/manager.yaml
+++ b/config/manager/containerinstances/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/core-network/manager.yaml
+++ b/config/manager/core-network/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/core/manager.yaml
+++ b/config/manager/core/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/dashboardservice/manager.yaml
+++ b/config/manager/dashboardservice/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/database/manager.yaml
+++ b/config/manager/database/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/databasemigration/manager.yaml
+++ b/config/manager/databasemigration/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/databasetools/manager.yaml
+++ b/config/manager/databasetools/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/datacatalog/manager.yaml
+++ b/config/manager/datacatalog/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/dataflow/manager.yaml
+++ b/config/manager/dataflow/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/dataintegration/manager.yaml
+++ b/config/manager/dataintegration/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/datalabelingservice/manager.yaml
+++ b/config/manager/datalabelingservice/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/datalabelingservicedataplane/manager.yaml
+++ b/config/manager/datalabelingservicedataplane/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/datasafe/manager.yaml
+++ b/config/manager/datasafe/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/datascience/manager.yaml
+++ b/config/manager/datascience/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/dbmulticloud/manager.yaml
+++ b/config/manager/dbmulticloud/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/delegateaccesscontrol/manager.yaml
+++ b/config/manager/delegateaccesscontrol/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/demandsignal/manager.yaml
+++ b/config/manager/demandsignal/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/desktops/manager.yaml
+++ b/config/manager/desktops/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/devops/manager.yaml
+++ b/config/manager/devops/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/dif/manager.yaml
+++ b/config/manager/dif/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/disasterrecovery/manager.yaml
+++ b/config/manager/disasterrecovery/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/distributeddatabase/manager.yaml
+++ b/config/manager/distributeddatabase/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/dns/manager.yaml
+++ b/config/manager/dns/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/email/manager.yaml
+++ b/config/manager/email/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/emwarehouse/manager.yaml
+++ b/config/manager/emwarehouse/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/events/manager.yaml
+++ b/config/manager/events/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/filestorage/manager.yaml
+++ b/config/manager/filestorage/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/fleetappsmanagement/manager.yaml
+++ b/config/manager/fleetappsmanagement/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/fleetsoftwareupdate/manager.yaml
+++ b/config/manager/fleetsoftwareupdate/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/functions/manager.yaml
+++ b/config/manager/functions/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/fusionapps/manager.yaml
+++ b/config/manager/fusionapps/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/gdp/manager.yaml
+++ b/config/manager/gdp/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/generativeai/manager.yaml
+++ b/config/manager/generativeai/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/generativeaiagent/manager.yaml
+++ b/config/manager/generativeaiagent/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/generativeaiagentruntime/manager.yaml
+++ b/config/manager/generativeaiagentruntime/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/generativeaidata/manager.yaml
+++ b/config/manager/generativeaidata/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/genericartifactscontent/manager.yaml
+++ b/config/manager/genericartifactscontent/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/goldengate/manager.yaml
+++ b/config/manager/goldengate/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/governancerulescontrolplane/manager.yaml
+++ b/config/manager/governancerulescontrolplane/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/healthchecks/manager.yaml
+++ b/config/manager/healthchecks/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/identity/manager.yaml
+++ b/config/manager/identity/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/integration/manager.yaml
+++ b/config/manager/integration/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/iot/manager.yaml
+++ b/config/manager/iot/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/jms/manager.yaml
+++ b/config/manager/jms/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/jmsjavadownloads/manager.yaml
+++ b/config/manager/jmsjavadownloads/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/jmsutils/manager.yaml
+++ b/config/manager/jmsutils/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/keymanagement/manager.yaml
+++ b/config/manager/keymanagement/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/licensemanager/manager.yaml
+++ b/config/manager/licensemanager/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/limits/manager.yaml
+++ b/config/manager/limits/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/limitsincrease/manager.yaml
+++ b/config/manager/limitsincrease/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/loadbalancer/manager.yaml
+++ b/config/manager/loadbalancer/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/lockbox/manager.yaml
+++ b/config/manager/lockbox/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/loganalytics/manager.yaml
+++ b/config/manager/loganalytics/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/logging/manager.yaml
+++ b/config/manager/logging/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/lustrefilestorage/manager.yaml
+++ b/config/manager/lustrefilestorage/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/managedkafka/manager.yaml
+++ b/config/manager/managedkafka/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/managementagent/manager.yaml
+++ b/config/manager/managementagent/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/managementdashboard/manager.yaml
+++ b/config/manager/managementdashboard/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/marketplace/manager.yaml
+++ b/config/manager/marketplace/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/marketplaceprivateoffer/manager.yaml
+++ b/config/manager/marketplaceprivateoffer/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/marketplacepublisher/manager.yaml
+++ b/config/manager/marketplacepublisher/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/mediaservices/manager.yaml
+++ b/config/manager/mediaservices/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/mngdmac/manager.yaml
+++ b/config/manager/mngdmac/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/monitoring/manager.yaml
+++ b/config/manager/monitoring/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/multicloud/manager.yaml
+++ b/config/manager/multicloud/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/mysql/manager.yaml
+++ b/config/manager/mysql/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/networkfirewall/manager.yaml
+++ b/config/manager/networkfirewall/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/networkloadbalancer/manager.yaml
+++ b/config/manager/networkloadbalancer/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/nosql/manager.yaml
+++ b/config/manager/nosql/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/objectstorage/manager.yaml
+++ b/config/manager/objectstorage/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/oce/manager.yaml
+++ b/config/manager/oce/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/ocicontrolcenter/manager.yaml
+++ b/config/manager/ocicontrolcenter/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/ocvp/manager.yaml
+++ b/config/manager/ocvp/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/oda/manager.yaml
+++ b/config/manager/oda/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/onesubscription/manager.yaml
+++ b/config/manager/onesubscription/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/ons/manager.yaml
+++ b/config/manager/ons/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/opa/manager.yaml
+++ b/config/manager/opa/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/opensearch/manager.yaml
+++ b/config/manager/opensearch/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/operatoraccesscontrol/manager.yaml
+++ b/config/manager/operatoraccesscontrol/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/opsi/manager.yaml
+++ b/config/manager/opsi/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/optimizer/manager.yaml
+++ b/config/manager/optimizer/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/osmanagementhub/manager.yaml
+++ b/config/manager/osmanagementhub/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/osubbillingschedule/manager.yaml
+++ b/config/manager/osubbillingschedule/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/osuborganizationsubscription/manager.yaml
+++ b/config/manager/osuborganizationsubscription/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/osubsubscription/manager.yaml
+++ b/config/manager/osubsubscription/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/psa/manager.yaml
+++ b/config/manager/psa/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/psql/manager.yaml
+++ b/config/manager/psql/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/queue/manager.yaml
+++ b/config/manager/queue/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/recovery/manager.yaml
+++ b/config/manager/recovery/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/redis/manager.yaml
+++ b/config/manager/redis/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/resourceanalytics/manager.yaml
+++ b/config/manager/resourceanalytics/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/resourcemanager/manager.yaml
+++ b/config/manager/resourcemanager/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/resourcescheduler/manager.yaml
+++ b/config/manager/resourcescheduler/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/rover/manager.yaml
+++ b/config/manager/rover/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/sch/manager.yaml
+++ b/config/manager/sch/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/securityattribute/manager.yaml
+++ b/config/manager/securityattribute/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/self/manager.yaml
+++ b/config/manager/self/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/servicecatalog/manager.yaml
+++ b/config/manager/servicecatalog/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/servicemanagerproxy/manager.yaml
+++ b/config/manager/servicemanagerproxy/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/stackmonitoring/manager.yaml
+++ b/config/manager/stackmonitoring/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/streaming/manager.yaml
+++ b/config/manager/streaming/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/tenantmanagercontrolplane/manager.yaml
+++ b/config/manager/tenantmanagercontrolplane/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/usageapi/manager.yaml
+++ b/config/manager/usageapi/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/vbsinst/manager.yaml
+++ b/config/manager/vbsinst/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/visualbuilder/manager.yaml
+++ b/config/manager/visualbuilder/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/vnmonitoring/manager.yaml
+++ b/config/manager/vnmonitoring/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/vulnerabilityscanning/manager.yaml
+++ b/config/manager/vulnerabilityscanning/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/waa/manager.yaml
+++ b/config/manager/waa/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/waas/manager.yaml
+++ b/config/manager/waas/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/waf/manager.yaml
+++ b/config/manager/waf/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/wlms/manager.yaml
+++ b/config/manager/wlms/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/config/manager/zpr/manager.yaml
+++ b/config/manager/zpr/manager.yaml
@@ -35,7 +35,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -46,6 +49,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -213,15 +219,9 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -431,7 +431,29 @@ $ operator-sdk cleanup oci-service-operator
 
 ### Customize CA trust bundle
 
-The OCI Service Operator for Kubernetes by default mounts the `/etc/pki` host path so that the host
-certificate chains can be used for TLS verification. The default container image is built on top of
-Oracle Linux 9 which has the default CA trust bundle under `/etc/pki`. A new container image can be
-created with a custom CA trust bundle.
+The default controller image is built on Oracle Linux 9 and uses the CA trust bundle included in the
+image. Controller Deployments do not mount the Kubernetes worker node's `/etc/pki` directory.
+
+For an environment that requires additional private or corporate certificate authorities, mount a
+complete PEM trust bundle from a ConfigMap or Secret and set `OCI_DEFAULT_CERTS_PATH` to the mounted
+file. The bundle must contain both the public roots needed for OCI endpoints and any additional
+private roots because the OCI SDK uses the configured file as its complete trust pool. For example:
+
+```yaml
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: OCI_DEFAULT_CERTS_PATH
+          value: /etc/osok-ca/ca-bundle.pem
+        volumeMounts:
+        - name: custom-ca
+          mountPath: /etc/osok-ca
+          readOnly: true
+      volumes:
+      - name: custom-ca
+        configMap:
+          name: osok-ca-bundle
+```

--- a/e2e/e2e-lite-local
+++ b/e2e/e2e-lite-local
@@ -832,22 +832,7 @@ EOF
     -o jsonpath='{range .spec.template.spec.volumes[*]}{@.name}{"\n"}{end}' \
     | awk '$0 == "pki" { print NR - 1; exit }')"
   if [ -n "${pki_mount_index}" ] || [ -n "${pki_volume_index}" ]; then
-    patch_ops="["
-    if [ -n "${pki_mount_index}" ]; then
-      patch_ops="${patch_ops}{\"op\":\"remove\",\"path\":\"/spec/template/spec/containers/0/volumeMounts/${pki_mount_index}\"}"
-    fi
-    if [ -n "${pki_volume_index}" ]; then
-      if [ "${patch_ops}" != "[" ]; then
-        patch_ops="${patch_ops},"
-      fi
-      patch_ops="${patch_ops}{\"op\":\"remove\",\"path\":\"/spec/template/spec/volumes/${pki_volume_index}\"}"
-    fi
-    patch_ops="${patch_ops}]"
-
-    log "Removing host /etc/pki override from deployment ${DEPLOYMENT_NAME} for local Kind trust"
-    "${KUBECTL_BIN}" -n "${PACKAGE_NAMESPACE}" patch deployment "${DEPLOYMENT_NAME}" \
-      --type=json \
-      -p="${patch_ops}" >/dev/null
+    die "deployment ${DEPLOYMENT_NAME} unexpectedly mounts host /etc/pki"
   fi
 
   log "Restarting deployment ${DEPLOYMENT_NAME} so updated secrets are re-read"

--- a/internal/generator/manager_security_test.go
+++ b/internal/generator/manager_security_test.go
@@ -1,0 +1,119 @@
+/*
+  Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+  Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+*/
+
+package generator
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func TestManagerDeploymentTemplateSatisfiesRestrictedPodSecurity(t *testing.T) {
+	t.Parallel()
+
+	content, err := renderManagerDeploymentFile()
+	if err != nil {
+		t.Fatalf("renderManagerDeploymentFile() error = %v", err)
+	}
+
+	assertRestrictedManagerDeployment(t, "manager deployment template", content)
+}
+
+func TestCheckedInManagerDeploymentsSatisfyRestrictedPodSecurity(t *testing.T) {
+	t.Parallel()
+
+	paths, err := filepath.Glob(filepath.Join("..", "..", "config", "manager", "*", "manager.yaml"))
+	if err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+	paths = append(paths, filepath.Join("..", "..", "config", "manager", "manager.yaml"))
+	slices.Sort(paths)
+
+	for _, path := range paths {
+		path := path
+		t.Run(filepath.ToSlash(path), func(t *testing.T) {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("ReadFile(%q) error = %v", path, err)
+			}
+			assertRestrictedManagerDeployment(t, path, string(content))
+		})
+	}
+}
+
+func assertRestrictedManagerDeployment(t *testing.T, source string, content string) {
+	t.Helper()
+
+	decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(content), 4096)
+	var deployment *appsv1.Deployment
+	for {
+		var candidate appsv1.Deployment
+		err := decoder.Decode(&candidate)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode %s: %v", source, err)
+		}
+		if candidate.Kind == "Deployment" {
+			deployment = &candidate
+			break
+		}
+	}
+	if deployment == nil {
+		t.Fatalf("%s did not contain a Deployment", source)
+	}
+
+	podSpec := deployment.Spec.Template.Spec
+	if podSpec.SecurityContext == nil {
+		t.Fatalf("%s does not define a pod security context", source)
+	}
+	if podSpec.SecurityContext.RunAsNonRoot == nil || !*podSpec.SecurityContext.RunAsNonRoot {
+		t.Errorf("%s does not require runAsNonRoot", source)
+	}
+	if podSpec.SecurityContext.RunAsUser == nil || *podSpec.SecurityContext.RunAsUser != 65532 {
+		t.Errorf("%s runAsUser = %v, want 65532", source, podSpec.SecurityContext.RunAsUser)
+	}
+	if podSpec.SecurityContext.SeccompProfile == nil || podSpec.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Errorf("%s does not use the RuntimeDefault seccomp profile", source)
+	}
+
+	for _, volume := range podSpec.Volumes {
+		if volume.HostPath != nil {
+			t.Errorf("%s volume %q uses forbidden hostPath %q", source, volume.Name, volume.HostPath.Path)
+		}
+	}
+
+	if len(podSpec.Containers) == 0 {
+		t.Fatalf("%s does not define a manager container", source)
+	}
+	for _, container := range podSpec.Containers {
+		securityContext := container.SecurityContext
+		if securityContext == nil {
+			t.Errorf("%s container %q does not define a security context", source, container.Name)
+			continue
+		}
+		if securityContext.AllowPrivilegeEscalation == nil || *securityContext.AllowPrivilegeEscalation {
+			t.Errorf("%s container %q does not disable privilege escalation", source, container.Name)
+		}
+		if securityContext.Capabilities == nil || !slices.Contains(securityContext.Capabilities.Drop, corev1.Capability("ALL")) {
+			t.Errorf("%s container %q does not drop all capabilities", source, container.Name)
+		}
+		for _, mount := range container.VolumeMounts {
+			if mount.MountPath == "/etc/pki" {
+				t.Errorf("%s container %q masks the image trust store with volume %q", source, container.Name, mount.Name)
+			}
+		}
+	}
+}

--- a/internal/generator/render.go
+++ b/internal/generator/render.go
@@ -1708,7 +1708,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -1719,6 +1722,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1886,17 +1892,11 @@ spec:
           - name: oci-credentials
             mountPath: /etc/oci
             readOnly: true
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
       volumes:
         - name: oci-credentials
           secret:
             secretName: ocicredentials
             optional: true
-        - name: pki
-          hostPath:
-            path: /etc/pki
       terminationGracePeriodSeconds: 10
 `
 


### PR DESCRIPTION
  ## Summary

  Fixes [OKE-44459](https://jira.oci.oraclecorp.com/browse/OKE-44459) by making OSOK
  manager deployments compatible with Kubernetes Restricted Pod Security.

  The controller now uses the CA trust bundle included in the Oracle Linux 9 image instead
  of mounting the worker node's `/etc/pki` directory.

  ## Changes

  - Remove the `/etc/pki` `hostPath` volume and mount from all manager deployments.
  - Apply Restricted Pod Security settings:
    - `runAsNonRoot: true`
    - `runAsUser: 65532`
    - `seccompProfile.type: RuntimeDefault`
    - `allowPrivilegeEscalation: false`
    - Drop all Linux capabilities
  - Update the generator template and all 146 checked-in manager manifests.
  - Add generator tests that validate the security settings and reject `hostPath` volumes
  or `/etc/pki` mounts.
  - Make local E2E fail if a generated deployment unexpectedly contains the old PKI mount.
  - Document custom CA configuration using a ConfigMap or Secret with
  `OCI_DEFAULT_CERTS_PATH`.

  ## CA behavior

  The default Oracle Linux 9 controller image includes the public CA trust bundle needed
  for OCI endpoints.

  Environments using private or corporate CAs can mount a complete PEM bundle from a
  ConfigMap or Secret and configure `OCI_DEFAULT_CERTS_PATH`.

  ## Validation

  - `make test` passed
    - Manifest and deepcopy generation
    - Formatting
    - `go vet ./...`
    - Full `go test ./...`
  - Verified no generated-file drift after testing.
  - Built and deployed the updated PSQL controller image to OKE.
  - Verified the controller starts under Restricted Pod Security without an `/etc/pki` host
  mount.
  - Verified PSQL create, read, update, and delete operations.
  - Verified OCI TLS connectivity using the CA bundle included in the image.
  - Verified Object Storage connectivity as an additional TLS sanity check.